### PR TITLE
fix: keep non-linebreak whitespaces

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ const range = str => str.split('-').map(c => `\\u${c}`).join('-');
 
 const CJK = cjk_ranges.map(range).join('');
 
-const regex = new RegExp(`([${CJK}])([\\s\\n]+)([${CJK}])`, 'gm');
+const regex = new RegExp(`([${CJK}])(\\s*\\n+\\s*)([${CJK}])`, 'gm');
 
 function joinCKJLines(tree) {
   visit(tree, 'text', node => {

--- a/test.js
+++ b/test.js
@@ -30,7 +30,13 @@ describe('remark-join-cjk-lines', () => {
     expect(output).toBe('汉字换，行');
   });
 
-  it('should keep the space between non-cjk charactors', () => {
+  it('should keep non-linebreak space between cjk characters', () => {
+    const input = ['汉字 换', '   行'].join('\n');
+    const output = process(input);
+    expect(output).toBe('汉字 换行');
+  });
+
+  it('should keep the space between non-cjk characters', () => {
     const input = ['non-cjk', '行'].join('\n');
     const output = process(input);
     expect(output).toBe('non-cjk\n行');


### PR DESCRIPTION
From the name of this plugin, I think non-linebreak spaces between CJK characters should be preserved and only those spaces between lines should be trimmed. Thanks.